### PR TITLE
Fix blah as foo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ func main() {
 		`package main
 
 func main() {
-	blah := 42
+	foo := 42
 
-	blah := true
+	foo := true
 }`
 	src := loc.NewDummySource(code)
 
@@ -91,7 +91,7 @@ Error: Found duplicate symbol 'foo' (at <dummy>:6:1)
     Note: Defined here at first (at <dummy>:4:1)
     Note: Previously defined as int (at <dummy>:4:1)
 
->       blah := true
+>       foo := true
 ```
 
 <img src="https://github.com/rhysd/ss/blob/master/loc/output.png?raw=true" width="371" alt="output screenshot"/>

--- a/doc.go
+++ b/doc.go
@@ -14,9 +14,9 @@ At first you should gain entire source as *Source instance.
     	`package main
 
     func main() {
-    	blah := 42
+    	foo := 42
 
-    	blah := true
+    	foo := true
     }
     `
     src := loc.NewDummySource(code)
@@ -64,7 +64,7 @@ Finally you can see the result!
     //   Note: Defined here at first (at <dummy>:4:1)
     //   Note: Previously defined as int (at <dummy>:4:1)
     //
-    // >       blah := true
+    // >       foo := true
     //
 
 Labels such as 'Error:' or 'Notes:' are colorized. Main error message is emphasized with bold font.

--- a/example_test.go
+++ b/example_test.go
@@ -12,9 +12,9 @@ func TestExample(t *testing.T) {
 		`package main
 
 func main() {
-	blah := 42
+	foo := 42
 
-	blah := true
+	foo := true
 }`
 	src := NewDummySource(code)
 
@@ -61,5 +61,5 @@ func main() {
 	//     Note: Defined here at first (at <dummy>:4:1)
 	//     Note: Previously defined as int (at <dummy>:4:1)
 	//
-	// >       blah := true
+	// >       foo := true
 }


### PR DESCRIPTION
They are mentioned as `foo` in other place (e.g. [here](https://github.com/rhysd/loc/blob/master/doc.go#L63).)